### PR TITLE
Add types to fibRoute.ts

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
+import Express from "express";
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req: Express.Request, res: Express.Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
Fixes the eslint error, solving issue #3, by adding types.

There's no functional change, but I can confirm that this fixes the linter errors without (after manually testing) breaking the `fib` API.

cc @OlegP-andrew for review